### PR TITLE
Fix hbind type signature to allow mapping to a different type

### DIFF
--- a/src/Hyper/Class/Monad.hs
+++ b/src/Hyper/Class/Monad.hs
@@ -36,8 +36,8 @@ instance HMonad Pure where
 
 -- | A variant of 'Control.Monad.(>>=)' for 'Hyper.Type.HyperType's
 hbind ::
-    (HMonad h, Recursively HFunctor p) =>
+    (HMonad h, Recursively HFunctor q) =>
     h # p ->
-    (forall n. HWitness h n -> p # n -> HCompose h p # n) ->
-    h # p
+    (forall n. HWitness h n -> p # n -> HCompose h q # n) ->
+    h # q
 hbind x f = _HCompose # hmap f x & hjoin


### PR DESCRIPTION
The result type and Recursively HFunctor constraint were both fixed to `p`, which forced hbind to map back to the same type. Generalize to `q` so the function argument can produce a different inner type.

Fixes #27 