### PR TITLE
Fix HasHPlain generation for direct children containing sums

### DIFF
--- a/src/Hyper/TH/HasPlain.hs
+++ b/src/Hyper/TH/HasPlain.hs
@@ -3,7 +3,8 @@
 -- | Generate 'HasHPlain' instances via @TemplateHaskell@
 module Hyper.TH.HasPlain
     ( makeHasHPlain
-    ) where
+    )
+where
 
 import qualified Control.Lens as Lens
 import qualified Data.Map as Map
@@ -146,7 +147,11 @@ makeCtr top param (cName, _, cFields) =
                 ?? id
                 <&> NodeField
         forField isTop (Right x) = forPat isTop x
-        forPat isTop (Node x) = forGen isTop x
+        -- A direct child is represented by @Pure # child@ in the plain form.
+        -- Do not flatten its single-constructor shape into the parent, or the
+        -- generated conversion loses that @Pure@ wrapper.
+        forPat _ (Node x) = forGen False x
+        -- forPat isTop (Node x) = forGen isTop x
         forPat isTop (GenEmbed x) = forGen isTop x
         forPat _ (InContainer t p) =
             FieldInfo

--- a/test/PlainTest.hs
+++ b/test/PlainTest.hs
@@ -1,5 +1,13 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module PlainTest where
 
+import Control.Exception (evaluate)
 import Control.Lens
 import GHC.Generics
 import Hyper
@@ -7,6 +15,33 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Prelude
+
+-- A direct single-constructor child must retain its `Pure` wrapper, even when
+-- the child itself contains a container of sum nodes.  Flattening `Child`
+-- into `Parent` used to make the generated `HasHPlain Parent` fail to typecheck.
+data Parent (h :: AHyperType) = Parent (h :# Child)
+
+data Child (h :: AHyperType) = Child [h :# (Leaf :+: Other)]
+
+data Leaf (h :: AHyperType) = Leaf String
+
+data Other (h :: AHyperType) = Other String
+
+makeHasHPlain [''Parent, ''Child, ''Leaf, ''Other]
+
+parentPlain :: HPlain Parent
+parentPlain =
+    hPlain
+        # Pure
+            ( Parent
+                (Pure (Child [Pure (L1 (Leaf "leaf"))]))
+            )
+
+regression :: TestTree
+regression =
+    testCase "HasHPlain: direct child containing a sum" $ do
+        _ <- evaluate parentPlain
+        pure ()
 
 test :: TestTree
 test =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,5 +9,5 @@ main :: IO ()
 main =
     testGroup
         "Tests"
-        [PlainTest.test]
+        [PlainTest.test, PlainTest.regression]
         & defaultMain


### PR DESCRIPTION
This PR is primarily intended to raise awareness of the issue. It fixes TH generation for hypertyped definitions that use `(:+:)`.

The fix was drafted with Codex’s help, and I do not fully understand the TH portion. Could someone confirm whether this is the right fix and whether it may have any unintended effects on other generated code?